### PR TITLE
Add sha256 & string to doxygen & cppcheck meta.yml

### DIFF
--- a/tools/cppcheck-conda-recipe/meta.yaml
+++ b/tools/cppcheck-conda-recipe/meta.yaml
@@ -3,10 +3,12 @@ package:
   version: '1.80'
 source:
   fn: 1.80.tar.gz
+  sha256: 20863db018d69c33648bdedcdc9d81d818b9064cc4333f0d4dc45e114bd0f000
   url: https://github.com/danmar/cppcheck/archive/1.80.tar.gz
 
 build:
-  number: 3
+  number: 4
+  string: 4
 
 requirements:
   build:

--- a/tools/doxygen-conda-recipe/meta.yaml
+++ b/tools/doxygen-conda-recipe/meta.yaml
@@ -6,11 +6,13 @@ package:
 source:
   url: ftp://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.13.src.tar.gz
   fn: doxygen-1.8.13.src.tar.gz
+  sha256: af667887bd7a87dc0dbf9ac8d86c96b552dfb8ca9c790ed1cbffaa6131573f6b
   patches:
   - find_iconv.patch
 
 build:
-  number: 1
+  number: 2
+  string: 2
 
 requirements:
   build:
@@ -31,3 +33,4 @@ test:
 about:
     home: http://www.stack.nl/~dimitri/doxygen/index.html
     license: GPLv3
+    summary: 'Documentation generator for C++ and other languages.'


### PR DESCRIPTION
A few minor updates:
1. Add `sha256` to meta.yml of cppcheck and doxygen. 
2. Add  `string` option to meta.yml of cppcheck and doxygen, updated packages on <https://anaconda.org/theochem/repo> so that the tar filenames look nicer.
3. Add a short summary for doxygen.