### PR TITLE
Fix bug in common.matches_filefilter

### DIFF
--- a/cardboardlint/common.py
+++ b/cardboardlint/common.py
@@ -171,8 +171,8 @@ def matches_filefilter(filename, rules):
         A filename to be tested.
     rules : list
         A list of strings, starting with - (exclude) or + (include), followed by a glob
-        pattern. Each file is tested against the rules in order. The first matching rule
-        is applied. If no rules match, the file is excluded.
+        pattern. Each file is tested against the rules in order. If no rules match, the
+        file is excluded.
 
     Returns
     -------
@@ -186,10 +186,12 @@ def matches_filefilter(filename, rules):
             raise ValueError('Unexpected first character in filename filter rule: {}'.format(
                 rule[0]))
 
+    accepted = []
     for rule in rules:
         pattern = rule[1:].strip()
         if fnmatch(filename, pattern):
-            return rule[0] == '+'
+            accepted.append(rule[0] == '+')
+    return len(accepted) > 0 and all(accepted)
 
 
 def get_offset_step(suffix):

--- a/cardboardlint/tests/test_common.py
+++ b/cardboardlint/tests/test_common.py
@@ -85,6 +85,7 @@ def test_matches_filefilter():
     assert matches_filefilter('foo/a.py', ['+ foo/*.py'])
     assert matches_filefilter('foo/a.py', ['- */test_*.py', '+ *.py'])
     assert not matches_filefilter('foo/test/test_a.py', ['- */test_*.py', '+ *.py'])
+    assert not matches_filefilter('foo/test/test_a.py', ['+ *.py', '- */test_*.py'])
     assert matches_filefilter('scripts/runfoo', ['+ scripts/*'])
 
     with assert_raises(ValueError):


### PR DESCRIPTION
`matches_filefilter` exits upon the first pattern that gets matched, which is okay if the patterns are disjoint from one another. However, if a filename satisfies more than one pattern, particularly when one is '+' (inclusive) and the other is '-' (exclusive), then the result differs depending on the order of the pattern. Added change checks that the conditions of all of the matched patterns are '+'.