### PR TITLE
Fix bug in linter_pylint.run_pylint

### DIFF
--- a/cardboardlint/linter_pylint.py
+++ b/cardboardlint/linter_pylint.py
@@ -74,7 +74,7 @@ def run_pylint(config, filenames):
         if len(output) > 0:
             for plmap in json.loads(output):
                 charno = plmap['column']
-                if charno == 0:
+                if charno in [0, -1]:
                     charno = None
                 messages.append(Message(
                     plmap['path'], plmap['line'], charno,


### PR DESCRIPTION
During the initialization of Message, `charno` must be a positive
integer. However, for pylint warning/errors that span multiple lines
(e.g. multiline comment using '''), `charno` (or column number in pylint) is
-1. This condition has been added.