### PR TITLE
Use yaml.safe_load

### DIFF
--- a/cardboardlint/__main__.py
+++ b/cardboardlint/__main__.py
@@ -171,7 +171,7 @@ def load_config(config_file):
 
     """
     with open(config_file, 'r') as f:
-        raw_config = yaml.load(f)
+        raw_config = yaml.safe_load(f)
 
     prefilter = raw_config.get('pre_filefilter', ['+ *'])
 


### PR DESCRIPTION
Fixes #90

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation